### PR TITLE
[loterre-resolvers] Get files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,10 @@
     "editor.formatOnSave": true,
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
-    }
+    },
+    "cSpell.words": [
+        "Loterre",
+        "venv",
+        "webdav"
+    ]
 }

--- a/loterre-resolvers/.dvc/.gitignore
+++ b/loterre-resolvers/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/loterre-resolvers/.dvc/config
+++ b/loterre-resolvers/.dvc/config
@@ -1,0 +1,2 @@
+[core]
+    autostage = true

--- a/loterre-resolvers/.dvcignore
+++ b/loterre-resolvers/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/loterre-resolvers/README.md
+++ b/loterre-resolvers/README.md
@@ -1,0 +1,53 @@
+# Loterre-resolvers
+
+Les données préparées dans ce répertoire servent pour le web service
+<https://github.com/Inist-CNRS/web-services/tree/main/services/loterre-resolvers>.
+
+## Installer DVC
+
+Pour installer DVC, il est conseillé de créer un environnement virtuel `.venv` :
+
+```bash
+python3 -m venv .venv/
+```
+
+Pour activer :
+
+```bash
+source .venv/bin/activate
+```
+
+Les commandes pour installer DVC sont :
+
+```bash
+pip install "dvc[webdav]==3.42.0"
+```
+
+## Configurer le remote DVC
+
+Dans le `.env` mettre les trois lignes suivantes :
+
+```bash
+export WEBDAV_URL=webdav://????????
+export WEBDAV_LOGIN=????
+export WEBDAV_PASSWORD=?????
+```
+
+Pour configurer le remote DVC :
+
+```bash
+source .env
+dvc init --subdir
+dvc remote add --local -d origin $WEBDAV_URL
+dvc remote modify --local origin user $WEBDAV_LOGIN
+dvc remote modify --local origin password $WEBDAV_PASSWORD
+dvc config core.autostage true
+```
+
+## Mettre à jour les fichiers
+
+1. se mettre dans ce répertoire: `cd loterre-resolvers`
+2. activer l'environnement virtuel: `source .venv/bin/activate`
+3. lancer le script: `./bin/get-files.sh`
+4. ajouter les fichiers à DVC: `dvc add ./data/*.skos`
+5. pousser les fichiers sur le remote: `dvc push`

--- a/loterre-resolvers/bin/get-files.sh
+++ b/loterre-resolvers/bin/get-files.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf "Downloading files...\n\n"
+
+printf "216\n"
+curl --progress-bar -o ./data/216.skos http://mapping-tables.daf.intra.inist.fr/216.skos
+
+printf "2XK - loterre-structures-recherche\n"
+curl --progress-bar -o ./data/2XK.skos http://mapping-tables.daf.intra.inist.fr/loterre-structures-recherche.xml
+
+printf "3JP\n"
+curl --progress-bar -o ./data/3JP.skos http://mapping-tables.daf.intra.inist.fr/3JP.skos
+
+printf "73G\n"
+curl --progress-bar -o ./data/73G.skos http://mapping-tables.daf.intra.inist.fr/73G.skos
+
+printf "9SD - loterre-pays\n"
+curl --progress-bar -o ./data/9SD.skos http://mapping-tables.daf.intra.inist.fr/loterre-pays.xml
+
+printf "BVM\n"
+curl --progress-bar -o ./data/BVM.skos http://mapping-tables.daf.intra.inist.fr/BVM.skos
+
+printf "D63 - loterre-communes\n"
+curl --progress-bar -o ./data/D63.skos http://mapping-tables.daf.intra.inist.fr/loterre-communes.xml
+
+printf "JVR - loterre-mesh\n"
+curl --progress-bar -o ./data/JVR.skos http://mapping-tables.daf.intra.inist.fr/loterre-mesh.xml
+
+printf "MDL\n"
+curl --progress-bar -o ./data/MDL.skos http://mapping-tables.daf.intra.inist.fr/MDL.skos
+
+printf "N9J\n"
+curl --progress-bar -o ./data/N9J.skos http://mapping-tables.daf.intra.inist.fr/N9J.skos
+
+printf "P21\n"
+curl --progress-bar -o ./data/P21.skos http://mapping-tables.daf.intra.inist.fr/P21.skos
+
+printf "P66\n"
+curl --progress-bar -o ./data/P66.skos http://mapping-tables.daf.intra.inist.fr/P66.skos
+
+printf "QX8\n"
+curl --progress-bar -o ./data/QX8.skos http://mapping-tables.daf.intra.inist.fr/QX8.skos

--- a/loterre-resolvers/data/.gitignore
+++ b/loterre-resolvers/data/.gitignore
@@ -1,0 +1,13 @@
+/216.skos
+/2XK.skos
+/3JP.skos
+/73G.skos
+/9SD.skos
+/BVM.skos
+/D63.skos
+/JVR.skos
+/MDL.skos
+/N9J.skos
+/P21.skos
+/P66.skos
+/QX8.skos

--- a/loterre-resolvers/data/216.skos.dvc
+++ b/loterre-resolvers/data/216.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 3adb88d03412ed4e4569b71b14354d0c
+  size: 1936035
+  hash: md5
+  path: 216.skos

--- a/loterre-resolvers/data/2XK.skos.dvc
+++ b/loterre-resolvers/data/2XK.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: b9c11f0d64f73cbd1109b8f80a0850e7
+  size: 28170863
+  hash: md5
+  path: 2XK.skos

--- a/loterre-resolvers/data/3JP.skos.dvc
+++ b/loterre-resolvers/data/3JP.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 8a20304e8bf72fd72c82879d922dc173
+  size: 2308578
+  hash: md5
+  path: 3JP.skos

--- a/loterre-resolvers/data/73G.skos.dvc
+++ b/loterre-resolvers/data/73G.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: f77a6ade78f20824c4ac32b5a5a290be
+  size: 2496320
+  hash: md5
+  path: 73G.skos

--- a/loterre-resolvers/data/9SD.skos.dvc
+++ b/loterre-resolvers/data/9SD.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 7a7ecf5ef02e07bfb0ca26af228a0ea9
+  size: 3078291
+  hash: md5
+  path: 9SD.skos

--- a/loterre-resolvers/data/BVM.skos.dvc
+++ b/loterre-resolvers/data/BVM.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 08e1013cdf5b8d13f9da6c318a9e90c4
+  size: 9635826
+  hash: md5
+  path: BVM.skos

--- a/loterre-resolvers/data/D63.skos.dvc
+++ b/loterre-resolvers/data/D63.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 990c26cb46fc302441f84ca46b6d0a28
+  size: 92156390
+  hash: md5
+  path: D63.skos

--- a/loterre-resolvers/data/JVR.skos.dvc
+++ b/loterre-resolvers/data/JVR.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 4ef3370991e26d92054eeb66c5f75b42
+  size: 117642710
+  hash: md5
+  path: JVR.skos

--- a/loterre-resolvers/data/MDL.skos.dvc
+++ b/loterre-resolvers/data/MDL.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 03fa07edb29af5a50801302722c8fb16
+  size: 5657134
+  hash: md5
+  path: MDL.skos

--- a/loterre-resolvers/data/N9J.skos.dvc
+++ b/loterre-resolvers/data/N9J.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 4cbae496c05d3d2a534f52c059153d90
+  size: 58246718
+  hash: md5
+  path: N9J.skos

--- a/loterre-resolvers/data/P21.skos.dvc
+++ b/loterre-resolvers/data/P21.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 3d44f296cb995aedae522a50a33b2762
+  size: 8495524
+  hash: md5
+  path: P21.skos

--- a/loterre-resolvers/data/P66.skos.dvc
+++ b/loterre-resolvers/data/P66.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 0c9cfd915beba169a839ebfa90c20c76
+  size: 3917649
+  hash: md5
+  path: P66.skos

--- a/loterre-resolvers/data/QX8.skos.dvc
+++ b/loterre-resolvers/data/QX8.skos.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 0e0210f8098cfa0d19918469480f60a0
+  size: 2027326
+  hash: md5
+  path: QX8.skos


### PR DESCRIPTION
In order to migrate from gitbucket to github, the reference files should be available via DVC.